### PR TITLE
Quitado enlace roto, waffle.io se retiró del mercado

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 [Esta aplicación está desplegada en **HEROKU**](http://proyectolobo.herokuapp.com/)
 
-[![Waffle.io - Columns and their card count](https://badge.waffle.io/joni182/lobo.svg?columns=all)](https://waffle.io/joni182/lobo)
-
 # Lobo
 
 ## Descripción


### PR DESCRIPTION
En el Readme.md seguía el enlace al waffle, pero ese servicio ya no existe.